### PR TITLE
fix #5: maxflow was broken when s = t

### DIFF
--- a/atcoder/maxflow.hpp
+++ b/atcoder/maxflow.hpp
@@ -65,6 +65,7 @@ template <class Cap> struct mf_graph {
     Cap flow(int s, int t, Cap flow_limit) {
         assert(0 <= s && s < _n);
         assert(0 <= t && t < _n);
+        assert(s != t);
 
         std::vector<int> level(_n), iter(_n);
         internal::simple_queue<int> que;

--- a/document_en/maxflow.md
+++ b/document_en/maxflow.md
@@ -48,6 +48,7 @@ It adds an edge oriented from the vertex `from` to the vertex `to` with the capa
 
 **@{keyword.constraints}**
 
+- $s \neq t$
 - The answer should be in `Cap`.
 
 **@{keyword.complexity}**

--- a/document_ja/maxflow.md
+++ b/document_ja/maxflow.md
@@ -49,6 +49,7 @@ int graph.add_edge(int from, int to, Cap cap);
 
 **@{keyword.constraints}**
 
+- $s \neq t$
 - 帰り値が `Cap` に収まる
 
 **@{keyword.complexity}**

--- a/test/unittest/maxflow_test.cpp
+++ b/test/unittest/maxflow_test.cpp
@@ -178,3 +178,10 @@ TEST(MaxflowTest, SelfLoop) {
     mf_graph<int>::edge e = {0, 0, 100, 0};
     edge_eq(e, g.get_edge(0));
 }
+
+TEST(MaxflowTest, Invalid) {
+    mf_graph<int> g(2);
+    // https://github.com/atcoder/ac-library/issues/5
+    EXPECT_DEATH(g.flow(0, 0), ".*");
+    EXPECT_DEATH(g.flow(0, 0, 0), ".*");
+}


### PR DESCRIPTION
We added `assert(s != t)`