### PR TITLE
Refactor expander.py

### DIFF
--- a/expander.py
+++ b/expander.py
@@ -17,6 +17,14 @@ class Expander:
         '#include\s*["<](atcoder/[a-z_]*(|.hpp))[">]\s*')
 
     include_guard = re.compile('#.*ATCODER_[A-Z_]*_HPP')
+    def is_ignored_line(self, line) -> bool:
+        if self.include_guard.match(line):
+            return True
+        if line.strip() == "#pragma once":
+            return True
+        if line.strip().startswith('//'):
+            return True
+        return False
 
     def __init__(self, lib_paths: List[Path]):
         self.lib_paths = lib_paths
@@ -45,14 +53,16 @@ class Expander:
 
         result = []  # type: List[str]
         for line in acl_source.splitlines():
-            if self.include_guard.match(line):
+            if self.is_ignored_line(line):
                 continue
-
+            
             m = self.atcoder_include.match(line)
             if m:
                 result.extend(self.expand_acl(m.group(1)))
                 continue
+
             result.append(line)
+
         return result
 
     def expand(self, source: str) -> str:

--- a/expander.py
+++ b/expander.py
@@ -17,6 +17,7 @@ class Expander:
         '#include\s*["<](atcoder/[a-z_]*(|.hpp))[">]\s*')
 
     include_guard = re.compile('#.*ATCODER_[A-Z_]*_HPP')
+
     def is_ignored_line(self, line) -> bool:
         if self.include_guard.match(line):
             return True
@@ -55,7 +56,7 @@ class Expander:
         for line in acl_source.splitlines():
             if self.is_ignored_line(line):
                 continue
-            
+
             m = self.atcoder_include.match(line)
             if m:
                 result.extend(self.expand_acl(m.group(1)))


### PR DESCRIPTION
We remove comment lines (start with '//'). It reduce the size of the expanded source (esp. we sometimes over the limit of codeforces by expanding 'atcoder/all')