### PR TITLE
#95: fix convolution

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "test/unittest/googletest"]
 	path = test/unittest/googletest
 	url = https://github.com/google/googletest
+[submodule "test/benchmark/benchmark"]
+	path = test/benchmark/benchmark
+	url = https://github.com/google/benchmark

--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_policy(SET CMP0048 NEW)
+project(ACLibrary)
+
+cmake_minimum_required(VERSION 3.17)
+
+set(GOOGLETEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../unittest/googletest")
+
+if(NOT "${CMAKE_CXX_STANDARD}")
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_compile_options(-Wall -Wextra -Wshadow -Wconversion -Wno-sign-conversion -Werror)
+
+add_subdirectory(benchmark)
+include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+include(GoogleTest)
+
+include_directories(.)
+include_directories(../../)
+
+add_executable(Convolution convolution.cpp)
+target_link_libraries(Convolution benchmark::benchmark)

--- a/test/benchmark/convolution.cpp
+++ b/test/benchmark/convolution.cpp
@@ -1,0 +1,35 @@
+#include "atcoder/convolution"
+#include <iostream>
+
+#include "benchmark/benchmark.h"
+
+using namespace std;
+using namespace atcoder;
+using mint = modint998244353;
+
+void CONV_same_length(benchmark::State& state) {    
+    vector<mint> a(state.range(0)), b(state.range(0));
+    for (int i = 0; i < state.range(0); i++) {
+        a[i] = i + 1234;
+        b[i] = i + 5678;
+    }
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(convolution(a, b));
+    }
+}
+BENCHMARK(CONV_same_length)->RangeMultiplier(2)->Range(1, 1<<20);
+BENCHMARK(CONV_same_length)->DenseRange(1, 100, 1);
+
+void CONV_long_empty(benchmark::State& state) {
+    vector<mint> a(state.range(0)), b;
+    for (int i = 0; i < state.range(0); i++) {
+        a[i] = i + 1234;
+    }
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(convolution(a, b));
+        benchmark::DoNotOptimize(convolution(b, a));
+    }
+}
+BENCHMARK(CONV_long_empty)->RangeMultiplier(2)->Range(1, 1 << 20);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
```
CONV_long_empty/1               170 ns          168 ns      4275723
CONV_long_empty/2               166 ns          165 ns      4142894
CONV_long_empty/4               167 ns          165 ns      4365042
CONV_long_empty/8               163 ns          162 ns      4345478
CONV_long_empty/16              166 ns          165 ns      4294479
CONV_long_empty/32              165 ns          164 ns      4280900
CONV_long_empty/64              246 ns          245 ns      2929422
CONV_long_empty/128             251 ns          250 ns      2787112
CONV_long_empty/256             192 ns          187 ns      3932120
CONV_long_empty/512             203 ns          198 ns      3421260
CONV_long_empty/1024            243 ns          236 ns      2986769
CONV_long_empty/2048            330 ns          328 ns      2129323
CONV_long_empty/4096            598 ns          595 ns      1182992
CONV_long_empty/8192           1661 ns         1646 ns       418113
CONV_long_empty/16384          3947 ns         3932 ns       176950
CONV_long_empty/32768          7546 ns         7500 ns        93090
CONV_long_empty/65536         17308 ns        17223 ns        40800
CONV_long_empty/131072        37341 ns        37135 ns        19057
CONV_long_empty/262144        79746 ns        79110 ns         8956
CONV_long_empty/524288       183291 ns       182162 ns         3583
CONV_long_empty/1048576      673876 ns       668803 ns         1070
```

->

```
CONV_long_empty/1              7.78 ns         7.75 ns     86059578
CONV_long_empty/2              7.94 ns         7.88 ns     86518020
CONV_long_empty/4              8.01 ns         7.94 ns     88622178
CONV_long_empty/8              7.97 ns         7.92 ns     88668204
CONV_long_empty/16             7.91 ns         7.87 ns     90345896
CONV_long_empty/32             8.02 ns         7.99 ns     87890012
CONV_long_empty/64             7.98 ns         7.94 ns     88263479
CONV_long_empty/128            8.03 ns         7.98 ns     87291591
CONV_long_empty/256            7.99 ns         7.95 ns     88373796
CONV_long_empty/512            8.16 ns         8.09 ns     88018207
CONV_long_empty/1024           7.87 ns         7.85 ns     87899945
CONV_long_empty/2048           8.20 ns         8.13 ns     86882051
CONV_long_empty/4096           7.97 ns         7.94 ns     89368928
CONV_long_empty/8192           7.93 ns         7.90 ns     89835729
CONV_long_empty/16384          7.93 ns         7.90 ns     89980076
CONV_long_empty/32768          7.90 ns         7.87 ns     84226738
CONV_long_empty/65536          8.02 ns         7.98 ns     87424596
CONV_long_empty/131072         7.96 ns         7.92 ns     88758147
CONV_long_empty/262144         7.95 ns         7.92 ns     88759272
CONV_long_empty/524288         7.87 ns         7.85 ns     85864285
CONV_long_empty/1048576        7.95 ns         7.90 ns     88205645
```