### PR TITLE
Remove unnecessary calculation in lazysegtree.hpp

### DIFF
--- a/atcoder/lazysegtree.hpp
+++ b/atcoder/lazysegtree.hpp
@@ -88,7 +88,7 @@ struct lazy_segtree {
 
         for (int i = log; i >= 1; i--) {
             if (((l >> i) << i) != l) push(l >> i);
-            if (((r >> i) << i) != r) push((r - 1) >> i);
+            if (((r >> i) << i) != r) push(r >> i);
         }
 
         {
@@ -105,7 +105,7 @@ struct lazy_segtree {
 
         for (int i = 1; i <= log; i++) {
             if (((l >> i) << i) != l) update(l >> i);
-            if (((r >> i) << i) != r) update((r - 1) >> i);
+            if (((r >> i) << i) != r) update(r >> i);
         }
     }
 


### PR DESCRIPTION
When `((r >> i) << i) != r` is true, the result of `(r - 1) >> i` is always the same as that of `r >> i` because the lower i bits are not zero.
There seems to be no reason to dare to write `(r - 1) >> i`.

Reference: https://twitter.com/rsk0315_h4x/status/1356532749264281600