### PR TITLE
Fix typo of MinCostFlow-en

### DIFF
--- a/document_en/mincostflow.md
+++ b/document_en/mincostflow.md
@@ -69,7 +69,7 @@ It returns $g$ as the list of the changepoints, that satisfies the followings.
 - Both of `.first` and `.second` are strictly increasing.
 - No three changepoints are on the same line.
 - (1) The last element of the list is $(x, g(x))$, where $x$ is the maximum amount of the $s-t$ flow.
-- (2) The last element of the list is $(y, g(y))$, where $y = \min(x, \mathrm{flow\_limit})$.
+- (2) The last element of the list is $(y, g(y))$, where $y = \min(x, \mathrm{flow\\_limit})$.
 
 **@{keyword.constraints}**
 


### PR DESCRIPTION
![typo](https://user-images.githubusercontent.com/30820469/112107084-dca34980-8bf1-11eb-908a-139f1b2e7a8d.PNG)

Underscore has not been rendered properly