### PR TITLE
Fft optimize

### DIFF
--- a/atcoder/convolution.hpp
+++ b/atcoder/convolution.hpp
@@ -22,11 +22,11 @@ struct fft_info {
     std::array<mint, rank2 + 1> root;   // root[i]^(2^i) == 1
     std::array<mint, rank2 + 1> iroot;  // root[i] * iroot[i] == 1
 
-    std::array<mint, std::max(0, rank2 - 2 + 1)> rate2;
-    std::array<mint, std::max(0, rank2 - 2 + 1)> irate2;
+    std::array<mint, std::max(0, rank2 - 1 + 1)> rate2;
+    std::array<mint, std::max(0, rank2 - 1 + 1)> irate2;
 
-    std::array<mint, std::max(0, rank2 - 3 + 1)> rate3;
-    std::array<mint, std::max(0, rank2 - 3 + 1)> irate3;
+    std::array<mint, std::max(0, rank2 - 2 + 1)> rate3;
+    std::array<mint, std::max(0, rank2 - 2 + 1)> irate3;
 
     fft_info() {
         root[rank2] = mint(g).pow((mint::mod() - 1) >> rank2);

--- a/atcoder/convolution.hpp
+++ b/atcoder/convolution.hpp
@@ -14,95 +14,165 @@ namespace atcoder {
 
 namespace internal {
 
+template <class mint,
+          int g = internal::primitive_root<mint::mod()>,
+          internal::is_static_modint_t<mint>* = nullptr>
+struct fft_info {
+    static constexpr int rank2 = bsf_constexpr(mint::mod() - 1);
+    std::array<mint, rank2 + 1> root;   // root[i]^(2^i) == 1
+    std::array<mint, rank2 + 1> iroot;  // root[i] * iroot[i] == 1
+
+    std::array<mint, std::max(0, rank2 - 2 + 1)> rate2;
+    std::array<mint, std::max(0, rank2 - 2 + 1)> irate2;
+
+    std::array<mint, std::max(0, rank2 - 3 + 1)> rate3;
+    std::array<mint, std::max(0, rank2 - 3 + 1)> irate3;
+
+    fft_info() {
+        root[rank2] = mint(g).pow((mint::mod() - 1) >> rank2);
+        iroot[rank2] = root[rank2].inv();
+        for (int i = rank2 - 1; i >= 0; i--) {
+            root[i] = root[i + 1] * root[i + 1];
+            iroot[i] = iroot[i + 1] * iroot[i + 1];
+        }
+
+        {
+            mint prod = 1, iprod = 1;
+            for (int i = 0; i <= rank2 - 2; i++) {
+                rate2[i] = root[i + 2] * prod;
+                irate2[i] = iroot[i + 2] * iprod;
+                prod *= iroot[i + 2];
+                iprod *= root[i + 2];
+            }
+        }
+        {
+            mint prod = 1, iprod = 1;
+            for (int i = 0; i <= rank2 - 3; i++) {
+                rate3[i] = root[i + 3] * prod;
+                irate3[i] = iroot[i + 3] * iprod;
+                prod *= iroot[i + 3];
+                iprod *= root[i + 3];
+            }
+        }
+    }
+};
+
 template <class mint, internal::is_static_modint_t<mint>* = nullptr>
 void butterfly(std::vector<mint>& a) {
-    static constexpr int g = internal::primitive_root<mint::mod()>;
     int n = int(a.size());
     int h = internal::ceil_pow2(n);
 
-    static bool first = true;
-    static mint sum_e[30];  // sum_e[i] = ies[0] * ... * ies[i - 1] * es[i]
-    if (first) {
-        first = false;
-        mint es[30], ies[30];  // es[i]^(2^(2+i)) == 1
-        int cnt2 = bsf(mint::mod() - 1);
-        mint e = mint(g).pow((mint::mod() - 1) >> cnt2), ie = e.inv();
-        for (int i = cnt2; i >= 2; i--) {
-            // e^(2^i) == 1
-            es[i - 2] = e;
-            ies[i - 2] = ie;
-            e *= e;
-            ie *= ie;
-        }
-        mint now = 1;
-        for (int i = 0; i <= cnt2 - 2; i++) {
-            sum_e[i] = es[i] * now;
-            now *= ies[i];
-        }
-    }
-    for (int ph = 1; ph <= h; ph++) {
-        int w = 1 << (ph - 1), p = 1 << (h - ph);
-        mint now = 1;
-        for (int s = 0; s < w; s++) {
-            int offset = s << (h - ph + 1);
-            for (int i = 0; i < p; i++) {
-                auto l = a[i + offset];
-                auto r = a[i + offset + p] * now;
-                a[i + offset] = l + r;
-                a[i + offset + p] = l - r;
+    static const fft_info<mint> info;
+
+    int len = 0;  // a[i, i+(n>>len), i+2*(n>>len), ..] is transformed
+    while (len < h) {
+        if (h - len == 1) {
+            int p = 1 << (h - len - 1);
+            mint rot = 1;
+            for (int s = 0; s < (1 << len); s++) {
+                int offset = s << (h - len);
+                for (int i = 0; i < p; i++) {
+                    auto l = a[i + offset];
+                    auto r = a[i + offset + p] * rot;
+                    a[i + offset] = l + r;
+                    a[i + offset + p] = l - r;
+                }
+                rot *= info.rate2[bsf(~(unsigned int)(s))];
             }
-            now *= sum_e[bsf(~(unsigned int)(s))];
+            len++;
+        } else {
+            // 4-base
+            int p = 1 << (h - len - 2);
+            mint rot = 1, imag = info.root[2];
+            for (int s = 0; s < (1 << len); s++) {
+                mint rot2 = rot * rot;
+                mint rot3 = rot2 * rot;
+                int offset = s << (h - len);
+                for (int i = 0; i < p; i++) {
+                    auto mod2 = 1ULL * mint::mod() * mint::mod();
+                    auto a0 = 1ULL * a[i + offset].val();
+                    auto a1 = 1ULL * a[i + offset + p].val() * rot.val();
+                    auto a2 = 1ULL * a[i + offset + 2 * p].val() * rot2.val();
+                    auto a3 = 1ULL * a[i + offset + 3 * p].val() * rot3.val();
+                    auto a1na3imag =
+                        1ULL * mint(a1 + mod2 - a3).val() * imag.val();
+                    auto na2 = mod2 - a2;
+                    a[i + offset] = a0 + a2 + a1 + a3;
+                    a[i + offset + 1 * p] = a0 + a2 + (2 * mod2 - (a1 + a3));
+                    a[i + offset + 2 * p] = a0 + na2 + a1na3imag;
+                    a[i + offset + 3 * p] = a0 + na2 + (mod2 - a1na3imag);
+                }
+                rot *= info.rate3[bsf(~(unsigned int)(s))];
+            }
+            len += 2;
         }
     }
 }
 
 template <class mint, internal::is_static_modint_t<mint>* = nullptr>
 void butterfly_inv(std::vector<mint>& a) {
-    static constexpr int g = internal::primitive_root<mint::mod()>;
     int n = int(a.size());
     int h = internal::ceil_pow2(n);
 
-    static bool first = true;
-    static mint sum_ie[30];  // sum_ie[i] = es[0] * ... * es[i - 1] * ies[i]
-    if (first) {
-        first = false;
-        mint es[30], ies[30];  // es[i]^(2^(2+i)) == 1
-        int cnt2 = bsf(mint::mod() - 1);
-        mint e = mint(g).pow((mint::mod() - 1) >> cnt2), ie = e.inv();
-        for (int i = cnt2; i >= 2; i--) {
-            // e^(2^i) == 1
-            es[i - 2] = e;
-            ies[i - 2] = ie;
-            e *= e;
-            ie *= ie;
-        }
-        mint now = 1;
-        for (int i = 0; i <= cnt2 - 2; i++) {
-            sum_ie[i] = ies[i] * now;
-            now *= es[i];
-        }
-    }
+    static const fft_info<mint> info;
 
-    for (int ph = h; ph >= 1; ph--) {
-        int w = 1 << (ph - 1), p = 1 << (h - ph);
-        mint inow = 1;
-        for (int s = 0; s < w; s++) {
-            int offset = s << (h - ph + 1);
-            for (int i = 0; i < p; i++) {
-                auto l = a[i + offset];
-                auto r = a[i + offset + p];
-                a[i + offset] = l + r;
-                a[i + offset + p] =
-                    (unsigned long long)(mint::mod() + l.val() - r.val()) *
-                    inow.val();
+    int len = h;  // a[i, i+(n>>len), i+2*(n>>len), ..] is transformed
+    while (len) {
+        if (len == 1) {
+            int p = 1 << (h - len);
+            mint irot = 1;
+            for (int s = 0; s < (1 << (len - 1)); s++) {
+                int offset = s << (h - len + 1);
+                for (int i = 0; i < p; i++) {
+                    auto l = a[i + offset];
+                    auto r = a[i + offset + p];
+                    a[i + offset] = l + r;
+                    a[i + offset + p] =
+                        (unsigned long long)(mint::mod() + l.val() - r.val()) *
+                        irot.val();
+                    ;
+                }
+                irot *= info.irate2[bsf(~(unsigned int)(s))];
             }
-            inow *= sum_ie[bsf(~(unsigned int)(s))];
+            len--;
+        } else {
+            // 4-base
+            int p = 1 << (h - len);
+            mint irot = 1, iimag = info.iroot[2];
+            for (int s = 0; s < (1 << (len - 2)); s++) {
+                mint irot2 = irot * irot;
+                mint irot3 = irot2 * irot;
+                int offset = s << (h - len + 2);
+                for (int i = 0; i < p; i++) {
+                    auto a0 = 1ULL * a[i + offset + 0 * p].val();
+                    auto a1 = 1ULL * a[i + offset + 1 * p].val();
+                    auto a2 = 1ULL * a[i + offset + 2 * p].val();
+                    auto a3 = 1ULL * a[i + offset + 3 * p].val();
+
+                    auto a2na3iimag =
+                        1ULL *
+                        mint((mint::mod() + a2 - a3) * iimag.val()).val();
+
+                    a[i + offset] = a0 + a1 + a2 + a3;
+                    a[i + offset + 1 * p] =
+                        (a0 + (mint::mod() - a1) + a2na3iimag) * irot.val();
+                    a[i + offset + 2 * p] =
+                        (a0 + a1 + (mint::mod() - a2) + (mint::mod() - a3)) *
+                        irot2.val();
+                    a[i + offset + 3 * p] =
+                        (a0 + (mint::mod() - a1) + (mint::mod() - a2na3iimag)) *
+                        irot3.val();
+                }
+                irot *= info.irate3[bsf(~(unsigned int)(s))];
+            }
+            len -= 2;
         }
     }
 }
 
 template <class mint, internal::is_static_modint_t<mint>* = nullptr>
-std::vector<mint> convolution_naive(const std::vector<mint>& a, const std::vector<mint>& b) {
+std::vector<mint> convolution_naive(const std::vector<mint>& a,
+                                    const std::vector<mint>& b) {
     int n = int(a.size()), m = int(b.size());
     std::vector<mint> ans(n + m - 1);
     if (n < m) {
@@ -150,7 +220,8 @@ std::vector<mint> convolution(std::vector<mint>&& a, std::vector<mint>&& b) {
 }
 
 template <class mint, internal::is_static_modint_t<mint>* = nullptr>
-std::vector<mint> convolution(const std::vector<mint>& a, const std::vector<mint>& b) {
+std::vector<mint> convolution(const std::vector<mint>& a,
+                              const std::vector<mint>& b) {
     int n = int(a.size()), m = int(b.size());
     if (!n || !m) return {};
     if (std::min(n, m) <= 60) return convolution_naive(a, b);

--- a/atcoder/convolution.hpp
+++ b/atcoder/convolution.hpp
@@ -22,11 +22,11 @@ struct fft_info {
     std::array<mint, rank2 + 1> root;   // root[i]^(2^i) == 1
     std::array<mint, rank2 + 1> iroot;  // root[i] * iroot[i] == 1
 
-    std::array<mint, std::max(0, rank2 - 1 + 1)> rate2;
-    std::array<mint, std::max(0, rank2 - 1 + 1)> irate2;
+    std::array<mint, std::max(0, rank2 - 2 + 1)> rate2;
+    std::array<mint, std::max(0, rank2 - 2 + 1)> irate2;
 
-    std::array<mint, std::max(0, rank2 - 2 + 1)> rate3;
-    std::array<mint, std::max(0, rank2 - 2 + 1)> irate3;
+    std::array<mint, std::max(0, rank2 - 3 + 1)> rate3;
+    std::array<mint, std::max(0, rank2 - 3 + 1)> irate3;
 
     fft_info() {
         root[rank2] = mint(g).pow((mint::mod() - 1) >> rank2);
@@ -77,7 +77,7 @@ void butterfly(std::vector<mint>& a) {
                     a[i + offset] = l + r;
                     a[i + offset + p] = l - r;
                 }
-                rot *= info.rate2[bsf(~(unsigned int)(s))];
+                if (s + 1 != (1 << len)) rot *= info.rate2[bsf(~(unsigned int)(s))];
             }
             len++;
         } else {
@@ -102,7 +102,7 @@ void butterfly(std::vector<mint>& a) {
                     a[i + offset + 2 * p] = a0 + na2 + a1na3imag;
                     a[i + offset + 3 * p] = a0 + na2 + (mod2 - a1na3imag);
                 }
-                rot *= info.rate3[bsf(~(unsigned int)(s))];
+                if (s + 1 != (1 << len)) rot *= info.rate3[bsf(~(unsigned int)(s))];
             }
             len += 2;
         }

--- a/atcoder/convolution.hpp
+++ b/atcoder/convolution.hpp
@@ -77,7 +77,8 @@ void butterfly(std::vector<mint>& a) {
                     a[i + offset] = l + r;
                     a[i + offset + p] = l - r;
                 }
-                if (s + 1 != (1 << len)) rot *= info.rate2[bsf(~(unsigned int)(s))];
+                if (s + 1 != (1 << len))
+                    rot *= info.rate2[bsf(~(unsigned int)(s))];
             }
             len++;
         } else {
@@ -102,7 +103,8 @@ void butterfly(std::vector<mint>& a) {
                     a[i + offset + 2 * p] = a0 + na2 + a1na3imag;
                     a[i + offset + 3 * p] = a0 + na2 + (mod2 - a1na3imag);
                 }
-                if (s + 1 != (1 << len)) rot *= info.rate3[bsf(~(unsigned int)(s))];
+                if (s + 1 != (1 << len))
+                    rot *= info.rate3[bsf(~(unsigned int)(s))];
             }
             len += 2;
         }
@@ -132,7 +134,8 @@ void butterfly_inv(std::vector<mint>& a) {
                         irot.val();
                     ;
                 }
-                if (s + 1 != (1 << len)) irot *= info.irate2[bsf(~(unsigned int)(s))];
+                if (s + 1 != (1 << (len - 1)))
+                    irot *= info.irate2[bsf(~(unsigned int)(s))];
             }
             len--;
         } else {
@@ -163,7 +166,8 @@ void butterfly_inv(std::vector<mint>& a) {
                         (a0 + (mint::mod() - a1) + (mint::mod() - a2na3iimag)) *
                         irot3.val();
                 }
-                if (s + 1 != (1 << len)) irot *= info.irate3[bsf(~(unsigned int)(s))];
+                if (s + 1 != (1 << (len - 2)))
+                    irot *= info.irate3[bsf(~(unsigned int)(s))];
             }
             len -= 2;
         }

--- a/atcoder/convolution.hpp
+++ b/atcoder/convolution.hpp
@@ -132,7 +132,7 @@ void butterfly_inv(std::vector<mint>& a) {
                         irot.val();
                     ;
                 }
-                irot *= info.irate2[bsf(~(unsigned int)(s))];
+                if (s + 1 != (1 << len)) irot *= info.irate2[bsf(~(unsigned int)(s))];
             }
             len--;
         } else {
@@ -163,7 +163,7 @@ void butterfly_inv(std::vector<mint>& a) {
                         (a0 + (mint::mod() - a1) + (mint::mod() - a2na3iimag)) *
                         irot3.val();
                 }
-                irot *= info.irate3[bsf(~(unsigned int)(s))];
+                if (s + 1 != (1 << len)) irot *= info.irate3[bsf(~(unsigned int)(s))];
             }
             len -= 2;
         }

--- a/atcoder/internal_bit.hpp
+++ b/atcoder/internal_bit.hpp
@@ -19,6 +19,14 @@ int ceil_pow2(int n) {
 
 // @param n `1 <= n`
 // @return minimum non-negative `x` s.t. `(n & (1 << x)) != 0`
+constexpr int bsf_constexpr(unsigned int n) {
+    int x = 0;
+    while (!(n & (1 << x))) x++;
+    return x;
+}
+
+// @param n `1 <= n`
+// @return minimum non-negative `x` s.t. `(n & (1 << x)) != 0`
 int bsf(unsigned int n) {
 #ifdef _MSC_VER
     unsigned long index;

--- a/test/unittest/convolution_test.cpp
+++ b/test/unittest/convolution_test.cpp
@@ -385,3 +385,34 @@ TEST(ConvolutionTest, Conv18433) {
 
     ASSERT_EQ(conv_naive<MOD>(a, b), convolution<MOD>(a, b));
 }
+
+TEST(ConvolutionTest, Conv2) {
+    std::vector<ll> empty = {};
+    ASSERT_EQ(empty, convolution<2>(empty, empty));
+}
+
+TEST(ConvolutionTest, Conv2147483647) {
+    const int MOD = 2147483647;
+    using mint = static_modint<MOD>;
+    std::vector<mint> a(1), b(2);
+    for (int i = 0; i < 1; i++) {
+        a[i] = randint(0, MOD - 1);
+    }
+    for (int i = 0; i < 2; i++) {
+        b[i] = randint(0, MOD - 1);
+    }
+    ASSERT_EQ(conv_naive(a, b), convolution(a, b));
+}
+
+TEST(ConvolutionTest, Conv2130706433) {
+    const int MOD = 2130706433;
+    using mint = static_modint<MOD>;
+    std::vector<mint> a(1024), b(1024);
+    for (int i = 0; i < 1024; i++) {
+        a[i] = randint(0, MOD - 1);
+    }
+    for (int i = 0; i < 1024; i++) {
+        b[i] = randint(0, MOD - 1);
+    }
+    ASSERT_EQ(conv_naive(a, b), convolution(a, b));
+}

--- a/test/unittest/convolution_test.cpp
+++ b/test/unittest/convolution_test.cpp
@@ -391,6 +391,19 @@ TEST(ConvolutionTest, Conv2) {
     ASSERT_EQ(empty, convolution<2>(empty, empty));
 }
 
+TEST(ConvolutionTest, Conv257) {
+    const int MOD = 257;
+    std::vector<ll> a(128), b(129);
+    for (int i = 0; i < 128; i++) {
+        a[i] = randint(0, MOD - 1);
+    }
+    for (int i = 0; i < 129; i++) {
+        b[i] = randint(0, MOD - 1);
+    }
+
+    ASSERT_EQ(conv_naive<MOD>(a, b), convolution<MOD>(a, b));
+}
+
 TEST(ConvolutionTest, Conv2147483647) {
     const int MOD = 2147483647;
     using mint = static_modint<MOD>;

--- a/test/unittest/modint_test.cpp
+++ b/test/unittest/modint_test.cpp
@@ -100,6 +100,29 @@ TEST(ModintTest, Mod1) {
     ASSERT_EQ(0, mint(true).val());
 }
 
+TEST(ModintTest, ModIntMax) {
+    modint::set_mod(INT32_MAX);
+    for (int i = 0; i < 100; i++) {
+        for (int j = 0; j < 100; j++) {
+            ASSERT_EQ((modint(i) * modint(j)).val(), i * j);
+        }
+    }
+    ASSERT_EQ((modint(1234) + modint(5678)).val(), 1234 + 5678);
+    ASSERT_EQ((modint(1234) - modint(5678)).val(), INT32_MAX - 5678 + 1234);
+    ASSERT_EQ((modint(1234) * modint(5678)).val(), 1234 * 5678);
+
+    using mint = static_modint<INT32_MAX>;
+    for (int i = 0; i < 100; i++) {
+        for (int j = 0; j < 100; j++) {
+            ASSERT_EQ((mint(i) * mint(j)).val(), i * j);
+        }
+    }
+    ASSERT_EQ((mint(1234) + mint(5678)).val(), 1234 + 5678);
+    ASSERT_EQ((mint(1234) - mint(5678)).val(), INT32_MAX - 5678 + 1234);
+    ASSERT_EQ((mint(1234) * mint(5678)).val(), 1234 * 5678);
+    ASSERT_EQ((mint(INT32_MAX) + mint(INT32_MAX)).val(), 0);
+}
+
 #ifndef _MSC_VER
 
 TEST(ModintTest, Int128) {
@@ -157,6 +180,13 @@ TEST(ModintTest, Inv) {
         if (gcd(i, 1'000'000'008) != 1) continue;
         int x = modint(i).inv().val();
         ASSERT_EQ(1, (ll(x) * i) % 1'000'000'008);
+    }
+
+    modint::set_mod(INT32_MAX);
+    for (int i = 1; i < 100000; i++) {
+        if (gcd(i, INT32_MAX) != 1) continue;
+        int x = modint(i).inv().val();
+        ASSERT_EQ(1, (ll(x) * i) % INT32_MAX);
     }
 }
 


### PR DESCRIPTION
This PR introduces 4-bases FFT for convolution and speed up. The result of benchmark is as follows:

Before:

```
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
CONV_same_length/1             13.8 ns         13.8 ns     50392558
CONV_same_length/2             17.4 ns         17.4 ns     40197565
CONV_same_length/4             29.9 ns         29.9 ns     23621755
CONV_same_length/8             84.7 ns         84.7 ns      8243246
CONV_same_length/16             306 ns          306 ns      2279322
CONV_same_length/32            1171 ns         1171 ns       596264
CONV_same_length/64            2864 ns         2864 ns       240826
CONV_same_length/128           6082 ns         6082 ns       114430
CONV_same_length/256          13056 ns        13056 ns        53707
CONV_same_length/512          27946 ns        27946 ns        24995
CONV_same_length/1024         60019 ns        60019 ns        11825
CONV_same_length/2048        125968 ns       125967 ns         5524
CONV_same_length/4096        268298 ns       268296 ns         2611
CONV_same_length/8192        580586 ns       580588 ns         1199
CONV_same_length/16384      1237440 ns      1237433 ns          565
CONV_same_length/32768      2616973 ns      2616977 ns          267
CONV_same_length/65536      5648103 ns      5648079 ns          125
CONV_same_length/131072    11793062 ns     11792968 ns           60
CONV_same_length/262144    24629007 ns     24628875 ns           28
CONV_same_length/524288    51344038 ns     51343554 ns           13
CONV_same_length/1048576  105986983 ns    105986967 ns            6
```

After:

```
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
CONV_same_length/1             13.8 ns         13.8 ns     49156026
CONV_same_length/2             17.9 ns         17.9 ns     39657967
CONV_same_length/4             31.2 ns         31.2 ns     22500225
CONV_same_length/8             85.0 ns         85.0 ns      8218895
CONV_same_length/16             306 ns          306 ns      2284680
CONV_same_length/32            1177 ns         1177 ns       591425
CONV_same_length/64            2498 ns         2498 ns       281165
CONV_same_length/128           5103 ns         5103 ns       137464
CONV_same_length/256          11161 ns        11161 ns        62321
CONV_same_length/512          23222 ns        23222 ns        30208
CONV_same_length/1024         50215 ns        50215 ns        13905
CONV_same_length/2048        103985 ns       103986 ns         6722
CONV_same_length/4096        228466 ns       228466 ns         3091
CONV_same_length/8192        481168 ns       481168 ns         1473
CONV_same_length/16384      1033450 ns      1033452 ns          677
CONV_same_length/32768      2170169 ns      2170174 ns          328
CONV_same_length/65536      4623062 ns      4623070 ns          152
CONV_same_length/131072     9460578 ns      9460592 ns           74
CONV_same_length/262144    20084465 ns     20084506 ns           34
CONV_same_length/524288    41024224 ns     41024259 ns           17
CONV_same_length/1048576   85474862 ns     85474975 ns            8
```