### PR TITLE
Fix MaxFlow::flow constraints

### DIFF
--- a/document_en/maxflow.md
+++ b/document_en/maxflow.md
@@ -50,6 +50,7 @@ It adds an edge oriented from the vertex `from` to the vertex `to` with the capa
 **@{keyword.constraints}**
 
 - $s \neq t$
+- $0 \leq s, t \lt n$
 - The answer should be in `Cap`.
 
 **@{keyword.complexity}**

--- a/document_ja/maxflow.md
+++ b/document_ja/maxflow.md
@@ -50,6 +50,7 @@ int graph.add_edge(int from, int to, Cap cap);
 **@{keyword.constraints}**
 
 - $s \neq t$
+- $0 \leq s, t \lt n$
 - 返り値が `Cap` に収まる
 
 **@{keyword.complexity}**


### PR DESCRIPTION
Only this section of the document was missing a description of the constraints.
The assert is present in the code.

https://github.com/atcoder/ac-library/blob/master/atcoder/maxflow.hpp#L67-L68