### PR TITLE
add: assert of convolution

### DIFF
--- a/atcoder/convolution.hpp
+++ b/atcoder/convolution.hpp
@@ -277,9 +277,9 @@ std::vector<long long> convolution_ll(const std::vector<long long>& a,
         internal::inv_gcd(MOD1 * MOD2, MOD3).second;
         
     static constexpr int MAX_AB_BIT = 24;
-    static_assert(MOD1 % (1ull << MAX_AB_BIT) == 1);
-    static_assert(MOD2 % (1ull << MAX_AB_BIT) == 1);
-    static_assert(MOD3 % (1ull << MAX_AB_BIT) == 1);
+    static_assert(MOD1 % (1ull << MAX_AB_BIT) == 1, "MOD1 isn't enough to support an array length of 2^24.");
+    static_assert(MOD2 % (1ull << MAX_AB_BIT) == 1, "MOD2 isn't enough to support an array length of 2^24.");
+    static_assert(MOD3 % (1ull << MAX_AB_BIT) == 1, "MOD3 isn't enough to support an array length of 2^24.");
     assert(a.size() + b.size() - 1 <= (1ull << MAX_AB_BIT));
 
     auto c1 = convolution<MOD1>(a, b);

--- a/atcoder/convolution.hpp
+++ b/atcoder/convolution.hpp
@@ -274,6 +274,12 @@ std::vector<long long> convolution_ll(const std::vector<long long>& a,
         internal::inv_gcd(MOD1 * MOD3, MOD2).second;
     static constexpr unsigned long long i3 =
         internal::inv_gcd(MOD1 * MOD2, MOD3).second;
+        
+    static constexpr int MAX_AB_BIT = 24;
+    static_assert(MOD1 % (1ull << MAX_AB_BIT) == 1);
+    static_assert(MOD2 % (1ull << MAX_AB_BIT) == 1);
+    static_assert(MOD3 % (1ull << MAX_AB_BIT) == 1);
+    assert(a.size() + b.size() - 1 <= (1ull << MAX_AB_BIT));
 
     auto c1 = convolution<MOD1>(a, b);
     auto c2 = convolution<MOD2>(a, b);

--- a/atcoder/convolution.hpp
+++ b/atcoder/convolution.hpp
@@ -199,6 +199,7 @@ template <class mint, internal::is_static_modint_t<mint>* = nullptr>
 std::vector<mint> convolution_fft(std::vector<mint> a, std::vector<mint> b) {
     int n = int(a.size()), m = int(b.size());
     int z = 1 << internal::ceil_pow2(n + m - 1);
+    assert(mint::mod() % z == 1);
     a.resize(z);
     internal::butterfly(a);
     b.resize(z);


### PR DESCRIPTION
Add assert for length of input $|a| + |b|$ in `convolution_ll` and `convolution_fft`.

https://github.com/atcoder/ac-library/blob/master/document_en/convolution.md?plain=1#L37

The following code should fail on assert
```c++
#include <vector>
#include <iostream>
#include <atcoder/convolution>
using namespace std;
using namespace atcoder;


void conv(const int n){
    vector<long long> a(n, 1);
    vector<long long> b(n, 1);

    auto res = convolution<998244353>(a, b);

    for(int i = 0; i < 100; ++i) {
        cout << i << ": " << res[i] << endl;
    }
}


void ll(const int n){
    vector<long long> a(n, 1);
    vector<long long> b(n, 1);

    auto res = convolution_ll(a, b);

    for(int i = 0; i < 100; ++i) {
        cout << i << ": " << res[i] << endl;
    }
}

int main(){
    conv(1 << 23);
    ll(1 << 24);
}
```