### PR TITLE
fix time complexty of maxflow

### DIFF
--- a/document_en/maxflow.md
+++ b/document_en/maxflow.md
@@ -55,8 +55,9 @@ It adds an edge oriented from the vertex `from` to the vertex `to` with the capa
 
 **@{keyword.complexity}**
 
-- $O(\min(n^{\frac{2}{3}}m, m^{\frac{3}{2}}))$ (if all the capacities are $1$) or
-- $O(n^2 m)$ (general),
+- $O((n + m) \sqrt{m})$ (if all the capacities are $1$),
+- $O(n^2 m)$ (general), or
+- $O(F(n + m))$, where $F$ is the returned value
 
 where $m$ is the number of added edges.
 

--- a/document_ja/maxflow.md
+++ b/document_ja/maxflow.md
@@ -57,8 +57,9 @@ int graph.add_edge(int from, int to, Cap cap);
 
 $m$ を追加された辺数として
 
-- $O(\min(n^{\frac{2}{3}}m, m^{\frac{3}{2}}))$ (辺の容量がすべて $1$ の時)
+- $O((n + m) \sqrt{m})$ (辺の容量がすべて $1$ の時)
 - $O(n^2 m)$
+- 返り値を $F$ として $O(F(n + m))$
 
 ## min_cut
 


### PR DESCRIPTION
The time complexity of maxflow is invalid actually.

Because our maxflow accepts multiple edges, we cannot archive $O(n^(2/3)m)$ for unit-capacity graph.

In addition to that, we should promise $O(F(n + m))$ as upper bound.