### PR TITLE
Update atcoder/internal_bit.hpp to use more efficient bit_ceil

### DIFF
--- a/atcoder/internal_bit.hpp
+++ b/atcoder/internal_bit.hpp
@@ -21,9 +21,14 @@ using std::bit_ceil;
 
 // @return same with std::bit::bit_ceil
 unsigned int bit_ceil(unsigned int n) {
-    unsigned int x = 1;
-    while (x < (unsigned int)(n)) x *= 2;
-    return x;
+    if (n == 0) return 1;
+    n--;
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    return n + 1;
 }
 
 #endif


### PR DESCRIPTION
This PR addresses [#187](https://github.com/atcoder/ac-library/issues/187) by replacing the loop-based implementation of bit_ceil with a constant-time version.

Let me know if everything looks okay.